### PR TITLE
Fixes-for-Issue-#3

### DIFF
--- a/blacklist.sh
+++ b/blacklist.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
+echo "Blacklist update started" > /config/scripts/blacklist-processing.txt ; 
+date >> /config/scripts/blacklist-processing.txt ;
 
-real_list=`grep -B1 "Dynamic Threat List" /config/config.boot | head -n 1 | awk '{print $2}'`
-[[ -z "$real_list" ]] && { echo "aborting"; exit -1; } || echo "Updating $real_list"
+real_list=$(grep -B1 "Dynamic Threat List" /config/config.boot | head -n 1 | awk '{print $2}'); [[ -z "$real_list" ]] && { echo "aborting"; exit 1; } || echo "Updating $real_list";
 
-ipset_list='temporary-list'
+ipset_list='temporary-list' ;
 
-sudo /sbin/ipset -! destroy $ipset_list
-sudo /sbin/ipset create $ipset_list hash:net
+sudo /sbin/ipset -! destroy $ipset_list ;
+sudo /sbin/ipset create $ipset_list hash:net ;
 
-for url in 'https://www.spamhaus.org/drop/edrop.txt' 'http://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt' 'https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1';
-do
- echo "Fetching and processing $url"
- curl "$url" | awk '/^[1-9]/ { print $1 }' | xargs -n1 sudo ipset -q add $ipset_list
-done
+for url in https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level2.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level3.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_webclient.netset
+do echo "Fetching and processing $url" ;
+ { echo "Processing blacklist" ; 
+  date ; 
+  echo $url ;
+ } >> /config/scripts/blacklist-processing.txt ;
+ curl "$url" | awk '/^[1-9]/ { print $1 }' | xargs -n1 sudo ipset -exist add $ipset_list ;
+done ;
 
-sudo /sbin/ipset swap $ipset_list $real_list
-sudo /sbin/ipset destroy $ipset_list
+sudo /sbin/ipset swap $ipset_list "$real_list" ;
+
+{ echo "Blacklist update finished" ; 
+ date ; 
+ echo "Blacklist contents" ; 
+ sudo /sbin/ipset list -s "$real_list" ;
+ } >> /config/scripts/blacklist-processing.txt ;
+ 
+sudo /sbin/ipset destroy $ipset_list ;

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -4,7 +4,8 @@
             "task": {
                 "blacklist": {
                     "executable": {
-                        "path": "/config/scripts/blacklist.sh"
+						"path": "/bin/bash",
+                        "arguments": "/config/scripts/blacklist.sh"
                     },
                     "interval": "24h"
                 }

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -4,7 +4,7 @@
             "task": {
                 "blacklist": {
                     "executable": {
-						"path": "/bin/bash",
+			"path": "/bin/bash",
                         "arguments": "/config/scripts/blacklist.sh"
                     },
                     "interval": "24h"


### PR DESCRIPTION
The fix for the blacklist.sh file is to put the do and echo "Fetching...." code on the same line.  What you have is syntax correct according to https://www.shellcheck.net/, but the USG cli fails to interrupt it correctly and it fails the script with a syntax error.  I have also updated other parts of the code to be code best practice based off of recommendations from https://www.shellcheck.net/.  I added logging into the script to /config/scripts/blacklist-processing.txt.  This log file will let the end user know that yes the script is running and what is has done.  It keeps track of the process starting, what URL is being processed, the final blacklist contents, and what time each step ran at.  I ran into a similar odd syntax error in my { echo "Processing..." section where if the { and echo "Processing..." are on separate lines the USG cli fails the script with a syntax error even though having them on separate lines is syntax correct according to https://www.shellcheck.net/.  So I had to put them on the same line to get the USG cli to interrupt it correctly.  I also updated the "xargs -n1 sudo ipset -q add..." line to "xargs -n1 sudo ipset -exist add..." as -q suppresses errors but does not stop the command from exiting due to an error it can't continue from.  Changing this to -exist will continue processing of the other entries and it will make it so only unique entries are added into your blacklist from all the URLs you are processing.  Reference https://ipset.netfilter.org/ipset.man.html.

You can also see I've updated the URLs you are using to use FireHOL.  These people are great and the lists I'm using are aggregates of the lists you had included plus many more.  You can check them out here https://github.com/firehol/blocklist-ipsets, http://iplists.firehol.org/, https://firehol.org/.

The config.gateway.json file had to be updated to call bash with the script as an argument.  I set a very low time interval in the json file and noticed that my log file was never getting created, and when I tried to call the script directly from the cli it ended with the following error "/config/scripts/blacklist.sh
-vbash: /config/scripts/blacklist.sh: /bin/bash^M: bad interpreter: No such file or directory".  This was true when calling the script as the user or using sudo.  It would however run as both the user and using sudo if I entered "bash /config/scripts/blacklist.sh" in the cli.  I referenced https://community.ui.com/questions/Deploying-USG-scripts-through-controller/d6e7457a-6dc8-4146-96bd-fecaff27f785 to see that this user called the program in the path section of the json file and then specified their script in the argument section of the json file.  After updating the json file my log file was getting created and the script was completing successfully.

Just a note to others out there that this script with my FireHOL URLs takes roughly 40 minutes to run so I would not recommend running this anymore than every few hours on your USG.

Scratch this me being a Windows guy and a Unix/Linux noob is where the syntax issues were coming from.  Creating the sh files on Windows puts CRLF at the end of each line and this system only wants a LF character so that's where the misinterpretation came from.